### PR TITLE
Installation instructions update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Single Server OpenStack Deployment
 .. note::
 
     See the full `Salt Formulas installation and usage instructions
-    <http://docs.saltstack.com/topics/conventions/formulas.html>`_.
+    <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
 Available states
 ----------------


### PR DESCRIPTION
It points to the current location of the install instructions.

It fixes issue #3
